### PR TITLE
use Show object for episode funcs

### DIFF
--- a/tvmaze/episode.go
+++ b/tvmaze/episode.go
@@ -18,10 +18,10 @@ type Episode struct {
 }
 
 // GetEpisodes finds all episodes for the given show
-func (c Client) GetEpisodes(s Show) (episodes []Episode, err error) {
+func (s Show) GetEpisodes() (episodes []Episode, err error) {
 	url := baseURLWithPath(fmt.Sprintf("shows/%d/episodes", s.ID))
 
-	if _, err = c.get(url, &episodes); err != nil {
+	if _, err = s.get(url, &episodes); err != nil {
 		return nil, err
 	}
 
@@ -29,11 +29,11 @@ func (c Client) GetEpisodes(s Show) (episodes []Episode, err error) {
 }
 
 // GetNextEpisode returns the next un-air episode for the show
-func (c Client) GetNextEpisode(s Show) (*Episode, error) {
+func (s Show) GetNextEpisode() (*Episode, error) {
 	url := baseURLWithPathQuery(fmt.Sprintf("shows/%d", s.ID), "embed", "nextepisode")
 
 	var embed embeddedNextEpisode
-	if _, err := c.get(url, &embed); err != nil {
+	if _, err := s.get(url, &embed); err != nil {
 		return nil, err
 	}
 
@@ -44,14 +44,14 @@ func (c Client) GetNextEpisode(s Show) (*Episode, error) {
 }
 
 // GetEpisode returns a specific episode for a show
-func (c Client) GetEpisode(s Show, season int, episode int) (*Episode, error) {
+func (s Show) GetEpisode(season int, episode int) (*Episode, error) {
 	url := baseURLWithPathQueries(fmt.Sprintf("shows/%d/episodebynumber", s.ID), map[string]string{
 		"season": strconv.Itoa(season),
 		"number": strconv.Itoa(episode),
 	})
 
 	var epOut Episode
-	if _, err := c.get(url, &epOut); err != nil {
+	if _, err := s.get(url, &epOut); err != nil {
 		return nil, err
 	}
 	return &epOut, nil

--- a/tvmaze/episode.go
+++ b/tvmaze/episode.go
@@ -57,6 +57,27 @@ func (s Show) GetEpisode(season int, episode int) (*Episode, error) {
 	return &epOut, nil
 }
 
+/*
+	Backwards compatibility
+*/
+// GetEpisodes finds all episodes for the given show
+func (c Client) GetEpisodes(s Show) (episodes []Episode, err error) {
+	fmt.Println("[WARN] (Client).GetEpisodes(Show) is deprecated.")
+	return s.GetEpisodes()
+}
+
+// GetNextEpisode returns the next un-air episode for the show
+func (c Client) GetNextEpisode(s Show) (*Episode, error) {
+	fmt.Println("[WARN] (Client).GetNextEpisode(Show) is deprecated.")
+	return s.GetNextEpisode()
+}
+
+// GetEpisode returns a specific episode for a show
+func (c Client) GetEpisode(s Show, season int, episode int) (*Episode, error) {
+	fmt.Println("[WARN] (Client).GetEpisode(Show) is deprecated.")
+	return s.GetEpisode(season, episode)
+}
+
 type embeddedNextEpisode struct {
 	Embedded struct {
 		NextEpisode Episode `json:"nextepisode"`

--- a/tvmaze/show.go
+++ b/tvmaze/show.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"reflect"
 	"strconv"
 	"time"
@@ -37,6 +38,20 @@ type Show struct {
 		Medium   string
 		Original string
 	}
+}
+
+func (s Show) get(url url.URL, ret interface{}) (status int, err error) {
+	r, err := http.Get(url.String())
+	if err != nil {
+		return 0, errors.Wrapf(err, "failed to get url: %s", url.String())
+	}
+
+	if r.StatusCode >= http.StatusBadRequest {
+		return r.StatusCode, errors.Errorf("received error status code (%d): %s", r.StatusCode, r.Status)
+	}
+
+	defer r.Body.Close()
+	return r.StatusCode, json.NewDecoder(r.Body).Decode(&ret)
 }
 
 // GetTitle return the show title

--- a/tvmaze/tvmaze_test.go
+++ b/tvmaze/tvmaze_test.go
@@ -44,7 +44,8 @@ func TestTVMaze(t *testing.T) {
 
 	t.Run("get episode", func(t *testing.T) {
 		t.Parallel()
-		result, err := c.GetEpisode(Show{ID: 315}, 4, 5)
+		show := Show{ID: 315}
+		result, err := show.GetEpisode(4, 5)
 		require.NoError(t, err)
 		require.NotNil(t, result, "expected a result")
 		require.NotEmpty(t, result.Name)
@@ -82,7 +83,7 @@ func TestTVMaze(t *testing.T) {
 	t.Run("get episodes", func(t *testing.T) {
 		t.Parallel()
 		show := Show{ID: 315} // Archer
-		episodes, err := c.GetEpisodes(show)
+		episodes, err := show.GetEpisodes()
 		require.NoError(t, err)
 		require.NotEmpty(t, episodes, "expected to get episodes")
 	})
@@ -90,7 +91,7 @@ func TestTVMaze(t *testing.T) {
 	t.Run("get next episode", func(t *testing.T) {
 		t.Parallel()
 		show := Show{ID: 1864} // Superstore
-		episode, err := c.GetNextEpisode(show)
+		episode, err := show.GetNextEpisode()
 		require.NoError(t, err)
 		require.NotNil(t, episode)
 	})
@@ -98,7 +99,7 @@ func TestTVMaze(t *testing.T) {
 	t.Run("null times", func(t *testing.T) {
 		t.Parallel()
 		show := Show{ID: 180} // Firefly
-		episodes, err := c.GetEpisodes(show)
+		episodes, err := show.GetEpisodes()
 		require.NoError(t, err)
 		require.NotEmpty(t, episodes, "expected to get episodes")
 	})


### PR DESCRIPTION
Made the episode functions use the Show object, instead of Client object. 
This also fixes the "cannot use show (type *tvmaze.Show) as type tvmaze.Show in argument to c.GetEpisodes" error.