### PR TITLE
feat(episode): implement EpisodeByDate

### DIFF
--- a/tvmaze/episode.go
+++ b/tvmaze/episode.go
@@ -58,9 +58,9 @@ func (s Show) GetEpisode(season int, episode int) (*Episode, error) {
 }
 
 // GetEpisodeDate returns an array of episodes for a show aired on that date
-func (s Show) GetEpisodeDate(year int, month int, day int) (episodes []Episode, error) {
+func (s Show) GetEpisodeDate(year int, month int, day int) (episodes []Episode, err error) {
 	url := baseURLWithPathQueries(fmt.Sprintf("shows/%d/episodesbydate", s.ID), map[string]string{
-		"date": fmt.Sprintf("%d-%d-%d", year, month, day)
+		"date": fmt.Sprintf("%d-%d-%d", year, month, day),
 	})
 
 	if _, err := s.get(url, &episodes); err != nil {

--- a/tvmaze/episode.go
+++ b/tvmaze/episode.go
@@ -57,6 +57,18 @@ func (s Show) GetEpisode(season int, episode int) (*Episode, error) {
 	return &epOut, nil
 }
 
+// GetEpisodeDate returns an array of episodes for a show aired on that date
+func (s Show) GetEpisodeDate(year int, month int, day int) (episodes []Episode, error) {
+	url := baseURLWithPathQueries(fmt.Sprintf("shows/%d/episodesbydate", s.ID), map[string]string{
+		"date": fmt.Sprintf("%d-%d-%d", year, month, day)
+	})
+
+	if _, err := s.get(url, &episodes); err != nil {
+		return nil, err
+	}
+	return episodes, nil
+}
+
 /*
 	Backwards compatibility
 */


### PR DESCRIPTION
This implements episodebydate. Presently this library doesn't appear to support daily shows, which is rather unfortunate to spin through the entire episode list to match the air date. Thankfully there's an episodesbydate endpoint on a show, which returns the episodes aired on that date.